### PR TITLE
fix redis-client compat for rails6+sidekiq7

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -156,7 +156,7 @@ module SidekiqScheduler
     # @return [Integer] epoch time of last run of the job
     def self.job_last_runtime(job_name)
       Sidekiq.redis do |r|
-        r.zrevrangebyscore(pushed_job_key(job_name), "(#{Time.now.to_i}", 0, limit: [0, 1]).first.to_i
+        r.zrange(pushed_job_key(job_name), "(#{Time.now.to_i}", 0, 'BYSCORE', 'REV', 'LIMIT', 0, 1).first.to_i
       end
     end
 


### PR DESCRIPTION
zrevrangebyscore/etc deprecated, plus syntax change
